### PR TITLE
PROJ-2555-app-text: Update AppText class for gray theme styling

### DIFF
--- a/packages/mobile/atoms/AppText.tsx
+++ b/packages/mobile/atoms/AppText.tsx
@@ -47,7 +47,7 @@ const textVariants = tv({
     {
       color: 'gray',
       highContrast: true,
-      class: 'text-light-type-gray-bold dark:text-dark-type-gray-bold',
+      class: 'text-light-type-gray-muted dark:text-dark-type-gray-muted',
     },
     {
       color: 'error',


### PR DESCRIPTION
Changed class names for gray theme to improve visual clarity and consistency. Adjusted 'text-light-type-gray-bold' to 'text-light-type-gray-muted' and 'dark:text-dark-type-gray-bold' to 'dark:text-dark-type-gray-muted'.